### PR TITLE
新增  推送markdown文章到直接微信公众号草稿

### DIFF
--- a/scripts/bash/format-wechat-haidao.sh
+++ b/scripts/bash/format-wechat-haidao.sh
@@ -1,0 +1,597 @@
+#!/usr/bin/env bash
+#
+# format-wechat-haidao.sh
+# 校验 wechat frontmatter, 上传本地资源并调用 HAIDAO HTTP 服务发布
+#
+# 使用方法:
+#   bash format-wechat-haidao.sh <publish/wechat.md>
+#
+
+set -euo pipefail
+
+INPUT_FILE=""
+REWRITE_SOURCE="${HAIDAO_REWRITE_SOURCE:-false}"
+THEME_OVERRIDE="${HAIDAO_THEME:-}"
+HIGHLIGHT_OVERRIDE="${HAIDAO_HIGHLIGHT:-}"
+
+THEME_CHOICES="default orangeheart rainbow lapis pie maize purple phycat haidao"
+HIGHLIGHT_CHOICES="atom-one-dark atom-one-light dracula github-dark github monokai solarized-dark solarized-light xcode"
+
+mask_secret() {
+  local value="${1:-}"
+  local length=${#value}
+  if [ "$length" -le 4 ]; then
+    printf '%s' "$value"
+    return
+  fi
+  local prefix="${value:0:4}"
+  local suffix="${value:length-4:4}"
+  local middle_length=$((length - 8))
+  local middle=""
+  if [ $middle_length -gt 0 ]; then
+    middle=$(printf '%*s' "$middle_length" '' | tr ' ' '*')
+  fi
+  printf '%s%s%s' "$prefix" "$middle" "$suffix"
+}
+
+validate_choice() {
+  local value="$1"; shift
+  local choices=("$@")
+  for item in "${choices[@]}"; do
+    if [ "$item" = "$value" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+print_help() {
+  cat <<'EOF'
+使用方法: bash format-wechat-haidao.sh [options] <publish/wechat.md>
+
+功能:
+  1. 校验 Markdown Frontmatter 是否包含 title 和 cover 字段
+  2. 自动上传 Markdown 中的本地资源并替换为远程 URL
+  3. 通过 HTTP Publish 服务提交内容
+
+可选参数:
+  -t <theme_id>          指定主题(default/orangeheart/rainbow/lapis/pie/maize/purple/phycat，或设 HAIDAO_THEME)
+-h <highlight_id>      指定代码高亮(atom-one-dark/atom-one-light/dracula/github-dark/github/monokai/solarized-dark/solarized-light/xcode，或设 HAIDAO_HIGHLIGHT)
+  --rewrite-source       上传后覆盖原 Markdown（等同设置 HAIDAO_REWRITE_SOURCE=true）
+  --no-rewrite-source    显式关闭覆盖，保持默认行为
+
+依赖:
+  - 环境变量 WECHAT_APP_ID / WECHAT_APP_SECRET
+  - 可访问的 HAIDAO HTTP 服务 (默认 http://localhost:3333)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      print_help
+      exit 0
+      ;;
+    -t|--theme)
+      if [ $# -lt 2 ]; then
+        echo "错误: -t/--theme 需要主题 ID" >&2
+        exit 1
+      fi
+      THEME_OVERRIDE="$2"
+      shift 2
+      continue
+      ;;
+    -h|--highlight)
+      if [ $# -lt 2 ]; then
+        echo "错误: -h/--highlight 需要代码高亮 ID" >&2
+        exit 1
+      fi
+      HIGHLIGHT_OVERRIDE="$2"
+      shift 2
+      continue
+      ;;
+    --rewrite-source)
+      REWRITE_SOURCE="true"
+      shift
+      ;;
+    --no-rewrite-source)
+      REWRITE_SOURCE="false"
+      shift
+      ;;
+    *)
+      if [ -z "$INPUT_FILE" ]; then
+        INPUT_FILE="$1"
+      else
+        echo "错误: 只能指定一个 Markdown 文件" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$INPUT_FILE" ]; then
+  echo "错误: 缺少输入文件参数" >&2
+  print_help
+  exit 1
+fi
+
+if [ ! -f "$INPUT_FILE" ]; then
+  echo "错误: 输入文件不存在: $INPUT_FILE" >&2
+  exit 1
+fi
+
+INPUT_ABS="$(cd "$(dirname "$INPUT_FILE")" && pwd)/$(basename "$INPUT_FILE")"
+INPUT_DIR="$(dirname "$INPUT_ABS")"
+
+# 获取项目根目录(查找 .content 目录)
+PROJECT_ROOT=""
+CURRENT_DIR="$(pwd)"
+
+while [ "$CURRENT_DIR" != "/" ]; do
+  if [ -d "$CURRENT_DIR/.content" ]; then
+    PROJECT_ROOT="$CURRENT_DIR"
+    break
+  fi
+  CURRENT_DIR="$(dirname "$CURRENT_DIR")"
+done
+
+if [ -z "$PROJECT_ROOT" ]; then
+  echo "错误: 无法找到项目根目录(.content目录)" >&2
+  exit 1
+fi
+
+CONFIG_FILE="$PROJECT_ROOT/.content/config.json"
+
+THEME=$(node -p "try { const c = require('$CONFIG_FILE'); c.formatting?.theme || 'default' } catch(e) { 'default' }" 2>/dev/null || echo "default")
+HIGHLIGHT=$(node -p "try { const c = require('$CONFIG_FILE'); c.formatting?.highlight || 'dracula' } catch(e) { 'dracula' }" 2>/dev/null || echo "dracula")
+
+if [ -n "$THEME_OVERRIDE" ]; then
+  if validate_choice "$THEME_OVERRIDE" $THEME_CHOICES; then
+    THEME="$THEME_OVERRIDE"
+  else
+    echo "错误: 不支持的主题: $THEME_OVERRIDE" >&2
+    echo "可选值: $THEME_CHOICES" >&2
+    exit 1
+  fi
+fi
+
+if [ -n "$HIGHLIGHT_OVERRIDE" ]; then
+  if validate_choice "$HIGHLIGHT_OVERRIDE" $HIGHLIGHT_CHOICES; then
+    HIGHLIGHT="$HIGHLIGHT_OVERRIDE"
+  else
+    echo "错误: 不支持的代码高亮: $HIGHLIGHT_OVERRIDE" >&2
+    echo "可选值: $HIGHLIGHT_CHOICES" >&2
+    exit 1
+  fi
+fi
+
+if [ -z "${WECHAT_APP_ID:-}" ] || [ -z "${WECHAT_APP_SECRET:-}" ]; then
+  echo "错误: 需要设置 WECHAT_APP_ID 和 WECHAT_APP_SECRET 环境变量以发布" >&2
+  exit 1
+fi
+
+echo "🔐 Debug: 当前将使用以下 Header 值"
+echo "   • WECHAT_APP_ID: $(mask_secret "$WECHAT_APP_ID")"
+echo "   • WECHAT_APP_SECRET: $(mask_secret "$WECHAT_APP_SECRET")"
+echo ""
+
+# 使用 Node 校验 frontmatter 并输出 title/cover
+FRONTMATTER_INFO="$(
+  node - <<'NODE' "$INPUT_ABS"
+const fs = require('fs');
+const file = process.argv[2];
+const content = fs.readFileSync(file, 'utf-8');
+const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+if (!match) {
+  console.error(`错误: ${file} 缺少 frontmatter, 需要以 --- 包裹的 YAML 区块`);
+  process.exit(1);
+}
+const lines = match[1].split(/\r?\n/);
+const data = {};
+for (const rawLine of lines) {
+  const line = rawLine.trim();
+  if (!line || line.startsWith('#')) continue;
+  if (/^[-]/.test(line)) continue; // 忽略简单列表
+  if (rawLine.startsWith(' ') || rawLine.startsWith('\t')) continue; // 忽略缩进行
+  const idx = line.indexOf(':');
+  if (idx === -1) continue;
+  const key = line.slice(0, idx).trim();
+  let value = line.slice(idx + 1).trim();
+  if (!value) continue;
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+  data[key] = value;
+}
+if (!data.title) {
+  console.error('错误: frontmatter 中缺少 title 字段');
+  process.exit(1);
+}
+if (!data.cover) {
+  console.error('错误: frontmatter 中缺少 cover 字段');
+  process.exit(1);
+}
+console.log(`TITLE=${data.title}`);
+console.log(`COVER=${data.cover}`);
+NODE
+)"
+
+if [ -z "$FRONTMATTER_INFO" ]; then
+  echo "错误: frontmatter 解析失败" >&2
+  exit 1
+fi
+
+TITLE=$(echo "$FRONTMATTER_INFO" | sed -n 's/^TITLE=//p' | head -n 1)
+COVER_RAW=$(echo "$FRONTMATTER_INFO" | sed -n 's/^COVER=//p' | head -n 1)
+
+if [ -z "$TITLE" ]; then
+  echo "错误: 未能解析到 frontmatter.title" >&2
+  exit 1
+fi
+
+if [ -z "$COVER_RAW" ]; then
+  echo "错误: 未能解析到 frontmatter.cover" >&2
+  exit 1
+fi
+
+VALID_COVER="false"
+if [[ "$COVER_RAW" =~ ^https?:// ]]; then
+  VALID_COVER="true"
+else
+  LOCAL_COVER=""
+  case "$COVER_RAW" in
+    /*)
+      LOCAL_COVER="$COVER_RAW"
+      ;;
+    "~/"*)
+      LOCAL_COVER="${HOME}${COVER_RAW:1}"
+      ;;
+    *)
+      LOCAL_COVER=$(node -p "require('path').resolve('$INPUT_DIR', '$COVER_RAW')" 2>/dev/null || echo "")
+      ;;
+  esac
+
+  if [ -n "${LOCAL_COVER:-}" ]; then
+    if [ -f "$LOCAL_COVER" ]; then
+      VALID_COVER="true"
+      COVER_RAW="$LOCAL_COVER"
+    else
+      echo "错误: cover 指向的本地图片不存在: $LOCAL_COVER (由 cover: $COVER_RAW 推导)" >&2
+      exit 1
+    fi
+  fi
+fi
+
+if [ "$VALID_COVER" != "true" ]; then
+  echo "错误: cover 必须为 http(s) 图片 URL 或本地绝对路径, 当前值: $COVER_RAW" >&2
+  exit 1
+fi
+
+API_BASE="${HAIDAO_API_BASE:-http://wechat.aisleep.yosuai.com}"
+UPLOAD_ENDPOINT="${HAIDAO_UPLOAD_ENDPOINT:-$API_BASE/upload}"
+PUBLISH_ENDPOINT="${HAIDAO_PUBLISH_ENDPOINT:-$API_BASE/publish}"
+
+echo "✅ Frontmatter 校验通过"
+echo "   • 标题: $TITLE"
+echo "   • 封面: $COVER_RAW"
+echo "   • HAIDAO 主题: $THEME"
+echo "   • Highlight: $HIGHLIGHT"
+echo "   • API 基址: $API_BASE"
+echo "   • 覆盖源文件: $REWRITE_SOURCE"
+echo ""
+
+TMP_MD="$(mktemp)"
+cleanup() {
+  rm -f "$TMP_MD"
+}
+trap cleanup EXIT
+
+COVER_LOCAL_PATH=""
+if [[ "$COVER_RAW" =~ ^https?:// ]]; then
+  COVER_IS_REMOTE="true"
+else
+  COVER_IS_REMOTE="false"
+  COVER_LOCAL_PATH="$COVER_RAW"
+fi
+
+echo "🖼️  检查 Markdown 中的本地资源..."
+
+HAIDAO_API_BASE="$API_BASE" \
+HAIDAO_UPLOAD_ENDPOINT="$UPLOAD_ENDPOINT" \
+COVER_LOCAL_PATH="$COVER_LOCAL_PATH" \
+COVER_IS_REMOTE="$COVER_IS_REMOTE" \
+REWRITE_SOURCE="$REWRITE_SOURCE" \
+node - "$INPUT_ABS" "$TMP_MD" <<'NODE'
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+const { Blob } = require('buffer');
+
+if (typeof fetch !== 'function') {
+  console.error('错误: 当前 Node 版本不支持 fetch API, 无法上传资源');
+  process.exit(1);
+}
+
+const inputPath = process.argv[2];
+const outputPath = process.argv[3];
+const inputDir = path.dirname(inputPath);
+const apiBase = process.env.HAIDAO_API_BASE || 'http://localhost:3333';
+const uploadEndpoint = process.env.HAIDAO_UPLOAD_ENDPOINT || `${apiBase.replace(/\/$/, '')}/upload`;
+const coverLocalPath = process.env.COVER_LOCAL_PATH || '';
+const isCoverRemote = process.env.COVER_IS_REMOTE === 'true';
+const rewriteSource = process.env.REWRITE_SOURCE === 'true';
+const appId = process.env.WECHAT_APP_ID;
+const appSecret = process.env.WECHAT_APP_SECRET;
+
+const content = fs.readFileSync(inputPath, 'utf-8');
+const fmMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+if (!fmMatch) {
+  console.error('错误: Markdown 缺少 frontmatter, 无法继续');
+  process.exit(1);
+}
+
+const fmBody = fmMatch[1];
+const fmLines = fmBody.split(/\r?\n/);
+let coverLineIndex = -1;
+let coverOriginalValue = '';
+
+for (let i = 0; i < fmLines.length; i++) {
+  const line = fmLines[i];
+  if (/^\s*cover\s*:/i.test(line)) {
+    coverLineIndex = i;
+    coverOriginalValue = line.replace(/^\s*cover\s*:/i, '').trim();
+    if ((coverOriginalValue.startsWith('"') && coverOriginalValue.endsWith('"')) || (coverOriginalValue.startsWith("'") && coverOriginalValue.endsWith("'"))) {
+      coverOriginalValue = coverOriginalValue.slice(1, -1);
+    }
+    break;
+  }
+}
+
+if (coverLineIndex === -1) {
+  console.error('错误: 未能在 frontmatter 中定位 cover 字段');
+  process.exit(1);
+}
+
+const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+const titlePattern = /\s+("[^"]*"|'[^']*'|\([^)]+\))$/;
+const isRemote = (t) => /^(?:[a-zA-Z][a-zA-Z\d+\-.]*:)?\/\//.test(t) || t.startsWith('data:');
+
+const uploadCache = new Map();
+
+const guessMime = (filePath) => {
+  const ext = path.extname(filePath).toLowerCase();
+  const mapping = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.webp': 'image/webp',
+    '.bmp': 'image/bmp',
+    '.mp4': 'video/mp4',
+    '.mov': 'video/quicktime',
+    '.mp3': 'audio/mpeg',
+    '.wav': 'audio/wav',
+    '.pdf': 'application/pdf'
+  };
+  return mapping[ext] || 'application/octet-stream';
+};
+
+let headersLogged = false;
+
+const maskSecret = (value = '') => {
+  if (!value) return '';
+  if (value.length <= 4) return value;
+  const prefix = value.slice(0, 4);
+  const suffix = value.slice(-4);
+  return `${prefix}${'*'.repeat(Math.max(0, value.length - 8))}${suffix}`;
+};
+
+const logHeadersOnce = (headers) => {
+  if (headersLogged) return;
+  headersLogged = true;
+  const printable = {};
+  for (const [key, val] of Object.entries(headers)) {
+    printable[key] = maskSecret(val);
+  }
+  console.error(`   • Debug Headers: ${JSON.stringify(printable)}`);
+};
+
+const uploadFile = async (localPath) => {
+  const absolutePath = path.resolve(localPath);
+  if (uploadCache.has(absolutePath)) {
+    return uploadCache.get(absolutePath);
+  }
+
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`本地资源不存在: ${absolutePath}`);
+  }
+
+  const promise = (async () => {
+    const mime = guessMime(absolutePath);
+    const buffer = await fsp.readFile(absolutePath);
+    const blob = new Blob([buffer], { type: mime });
+    const form = new FormData();
+    form.append('file', blob, path.basename(absolutePath));
+    form.append('content_type', mime);
+
+    const headers = {};
+    if (appId) {
+      headers['WECHAT_APP_ID'] = appId;
+    }
+    if (appSecret) {
+      headers['WECHAT_APP_SECRET'] = appSecret;
+    }
+
+    console.error(`   • 正在上传本地文件: ${absolutePath}`);
+
+    const requestInit = {
+      method: 'POST',
+      headers,
+      body: form
+    };
+
+    logHeadersOnce(headers);
+
+    const response = await fetch(uploadEndpoint, requestInit);
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`上传失败(${response.status}) - 文件: ${absolutePath}: ${text}`);
+    }
+
+    const data = await response.json();
+    if (!data || !data.url) {
+      throw new Error(`上传响应缺少 url 字段: ${JSON.stringify(data)}`);
+    }
+
+    console.error(`   • 已上传 ${absolutePath} -> ${data.url}`);
+    return data.url;
+  })();
+
+  uploadCache.set(absolutePath, promise);
+  return promise;
+};
+
+const sanitizeValue = (value) => {
+  if (value === undefined || value === null) return '';
+  if (/\s/.test(value)) {
+    return `"${value.replace(/"/g, '\"')}"`;
+  }
+  return value;
+};
+
+const resolveLocal = (target) => {
+  if (path.isAbsolute(target)) return target;
+  if (target.startsWith('~/')) {
+    return path.join(process.env.HOME || '', target.slice(2));
+  }
+  return path.resolve(inputDir, target);
+};
+
+const stripAngles = (value) => {
+  if (value.startsWith('<') && value.endsWith('>')) {
+    return value.slice(1, -1).trim();
+  }
+  return value;
+};
+
+const processTarget = async (rawTarget) => {
+  const trimmed = rawTarget.trim();
+  let titleSuffix = '';
+  let urlPart = trimmed;
+
+  const titleMatch = trimmed.match(titlePattern);
+  if (titleMatch) {
+    titleSuffix = titleMatch[1];
+    urlPart = trimmed.slice(0, trimmed.length - titleMatch[0].length).trim();
+  }
+
+  urlPart = stripAngles(urlPart);
+
+  if (isRemote(urlPart)) {
+    return { url: urlPart, titleSuffix };
+  }
+
+  const resolvedPath = resolveLocal(urlPart);
+  const uploadedUrl = await uploadFile(resolvedPath);
+  return { url: uploadedUrl, titleSuffix };
+};
+
+const transformBody = async (body) => {
+  imageRegex.lastIndex = 0;
+  let lastIndex = 0;
+  let result = '';
+  let match;
+
+  while ((match = imageRegex.exec(body)) !== null) {
+    const [full, alt = '', targetRaw] = match;
+    result += body.slice(lastIndex, match.index);
+    const { url, titleSuffix } = await processTarget(targetRaw);
+    const titlePart = titleSuffix ? ` ${titleSuffix}` : '';
+    result += `![${alt}](${url}${titlePart})`;
+    lastIndex = match.index + full.length;
+  }
+
+  result += body.slice(lastIndex);
+  return result;
+};
+
+(async () => {
+  try {
+    let coverValue = coverOriginalValue;
+    if (!isCoverRemote && coverLocalPath) {
+      coverValue = await uploadFile(coverLocalPath);
+      console.error(`   • 封面替换为远程链接: ${coverValue}`);
+    }
+
+    const updatedFmLines = [...fmLines];
+    updatedFmLines[coverLineIndex] = `cover: ${sanitizeValue(coverValue)}`;
+    const newFrontmatter = `---\n${updatedFmLines.join('\n')}\n---`;
+    const prefix = content.slice(0, fmMatch.index ?? 0);
+    const body = content.slice((fmMatch.index ?? 0) + fmMatch[0].length);
+    const newBody = await transformBody(body);
+    const finalContent = `${prefix}${newFrontmatter}${newBody}`;
+    fs.writeFileSync(outputPath, finalContent, 'utf-8');
+    if (rewriteSource) {
+      fs.writeFileSync(inputPath, finalContent, 'utf-8');
+      console.error(`   • 已覆盖原 Markdown: ${inputPath}`);
+    }
+  } catch (err) {
+    console.error(`错误: ${err.message}`);
+    process.exit(1);
+  }
+})();
+NODE
+
+echo "📄 已生成替换资源后的临时 Markdown: $TMP_MD"
+
+PUBLISH_PAYLOAD=$(node - "$TMP_MD" "$THEME" "$HIGHLIGHT" <<'NODE'
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf-8');
+const theme = process.argv[3] || 'default';
+const highlight = process.argv[4] || '';
+const payload = {
+  content,
+  theme_id: theme
+};
+if (highlight) {
+  payload.highlight_id = highlight;
+}
+process.stdout.write(JSON.stringify(payload));
+NODE
+)
+
+echo "🚀 正在调用发布接口: $PUBLISH_ENDPOINT"
+echo "   • Header WECHAT_APP_ID: $(mask_secret "$WECHAT_APP_ID")"
+echo "   • Header WECHAT_APP_SECRET: $(mask_secret "$WECHAT_APP_SECRET")"
+echo ""
+
+set +e
+HTTP_RESPONSE=$(curl --silent --show-error --write-out "\n%{http_code}" \
+  -X POST "$PUBLISH_ENDPOINT" \
+  -H "Content-Type: application/json" \
+  -H "WECHAT_APP_ID: $WECHAT_APP_ID" \
+  -H "WECHAT_APP_SECRET: $WECHAT_APP_SECRET" \
+  -d "$PUBLISH_PAYLOAD")
+STATUS=$?
+set -e
+
+if [ $STATUS -ne 0 ]; then
+  echo "❌ 发布请求失败" >&2
+  exit $STATUS
+fi
+
+HTTP_STATUS=$(printf '%s' "$HTTP_RESPONSE" | tail -n 1)
+HTTP_BODY="${HTTP_RESPONSE%$'\n'$HTTP_STATUS}"
+
+if [[ "$HTTP_STATUS" -lt 200 || "$HTTP_STATUS" -ge 300 ]]; then
+  echo "❌ 发布接口返回错误 ($HTTP_STATUS):" >&2
+  echo "$HTTP_BODY" >&2
+  exit 1
+fi
+
+echo "🎉 发布成功"
+echo "$HTTP_BODY"
+exit 0

--- a/templates/commands/fabu.md
+++ b/templates/commands/fabu.md
@@ -1,0 +1,206 @@
+---
+description: 使用内置脚本发布文章 (微信公众号/视频脚本/通用格式)
+argument-hint: 无需参数,自动识别工作区类型
+allowed-tools: Read(//workspaces/**/draft.md, //.content/config.json), Bash, Write
+---
+
+# 发布准备
+
+## 功能说明
+
+根据 `.content/config.json` 中的 `workspace` 类型，统一调用内置脚本或复制命令，生成最终可发布版本。
+
+## ⚠️ 重要提醒
+
+- **必须先读取 `.content/config.json`**，禁止猜测工作区类型。
+- **禁止手动拼接 HTML**，所有公众号排版一律通过提供的脚本完成。
+- **非公众号工作区** 不得调用公众号脚本。
+
+---
+
+## 支持平台
+
+| workspace | 目标平台 | 输出文件 |
+|-----------|----------|----------|
+| `wechat`  | 微信公众号 | `publish/wechat.md` |
+| `video`   | 视频脚本   | `publish/video-script.md` |
+| `general` | 通用 Markdown | `publish/article.md` |
+
+---
+
+## 发布总流程
+
+1. 读取 `.content/config.json` → 确认 `workspace`、格式化配置。
+2. 找到文章目录 `workspaces/<type>/articles/<slug>/`，检查 `draft.md`。
+3. 在文章目录执行 `/fabu`，生成 `publish/` 目录及目标稿件。
+4. 根据工作区类型执行自动化处理（公众号需运行脚本，其他类型仅复制文件）。
+5. 在 `publish/` 目录编写 `metadata.json`，补齐标题、日期等信息。
+
+> `/fabu` 只会生成当前工作区需要的文件，不会跨类型输出。
+
+---
+
+## 微信公众号发布流程（仅当 `workspace = "wechat"`）
+
+### 1. 读取配置
+
+```bash
+cat .content/config.json
+```
+
+- 确认 `workspace` 为 `wechat`。
+- 记录 `formatting` 中的主题/高亮，以便脚本自动读取。
+
+### 2. 准备稿件
+
+`wechat.md` 必须以 frontmatter 开头，并至少包括 `title`、`cover` 字段：
+
+```
+---
+title: 示例标题
+cover: /Users/me/Pictures/cover.jpg
+---
+
+正文...
+```
+
+- `title`：公众号标题；
+- `cover`：正文无首图时必填，可用 http(s) 链接或本地绝对路径；
+- frontmatter 会被 `/publish` 保留在 `publish/wechat.md` 中。
+
+### 3. 执行 `/fabu`
+
+在文章目录运行：
+
+```bash
+/fabu
+```
+
+目录结构示例：
+
+```
+workspaces/wechat/articles/<slug>/
+└── publish/
+    ├── wechat.md
+    ├── images/
+    └── metadata.json (需补充)
+```
+
+### 4. 调用自动化脚本
+
+> 所有公众号排版仅允许调用以下路径：`/Users/YanHaidao/Sites/SPEC/my-article/.content/scripts/bash/format-wechat-haidao.sh`
+
+执行示例：
+
+```bash
+WECHAT_APP_ID="<AppID>" \
+WECHAT_APP_SECRET="<AppSecret>" \
+bash .content/scripts/bash/format-wechat-haidao.sh \
+  workspaces/wechat/articles/<slug>/publish/wechat.md
+```
+
+说明：
+- 使用绝对路径调用脚本，禁止改为相对路径或其他脚本；
+- 仅传入 `wechat.md` 路径一个参数；
+- 主题/高亮等样式由脚本自动读取，不需额外参数；
+- **脚本输出即可作为发布结果，不需要单独保存 HTML 渲染内容**。
+
+若脚本报错，请根据提示修正 frontmatter 或图片路径后重试。
+
+### 5. 维护 `metadata.json`
+
+在 `publish/` 目录写入：
+
+```json
+{
+  "title": "文章标题",
+  "date": "YYYY-MM-DD",
+  "platform": "wechat",
+  "tool": "auto-script"
+}
+```
+
+可根据需要补充标签、摘要、作者等字段。
+
+---
+
+## 非 WeChat 工作区
+
+这些工作区只需复制 `draft.md` 成目标文件，再维护 `metadata.json`，不需要运行脚本。
+
+### video
+
+```bash
+mkdir -p workspaces/video/articles/<slug>/publish
+cp workspaces/video/articles/<slug>/draft.md \
+   workspaces/video/articles/<slug>/publish/video-script.md
+```
+
+### general
+
+```bash
+mkdir -p workspaces/general/articles/<slug>/publish
+cp workspaces/general/articles/<slug>/draft.md \
+   workspaces/general/articles/<slug>/publish/article.md
+```
+
+---
+
+## metadata.json 参考结构
+
+```json
+{
+  "title": "Claude Code vs Cursor: 5个真实场景深度对比",
+  "subtitle": "用数据说话,帮你选对AI编程助手",
+  "author": "用户名",
+  "date": "2025-01-15",
+  "tags": ["AI编程", "Claude Code", "Cursor", "工具评测"],
+  "summary": "通过5个真实开发场景的深度测试...",
+  "platforms": {
+    "wechat": {
+      "category": "科技",
+      "原创": true
+    }
+  }
+}
+```
+
+---
+
+## 输出反馈模板（wechat）
+
+```
+✅ 公众号稿件生成完成！
+
+📄 发布文件: workspaces/wechat/articles/<slug>/publish/wechat.md
+⚙️ 调用脚本: /Users/YanHaidao/Sites/SPEC/my-article/.content/scripts/bash/format-wechat-haidao.sh
+📝 元信息: publish/metadata.json
+
+💡 下一步:
+1. 复制脚本输出内容。
+2. 登录公众号后台粘贴并检查排版。
+3. 根据需要调整封面/标签。
+```
+
+---
+
+## 常见问题
+
+- **Q:** `command not found`?  
+  **A:** 请确认上述脚本路径存在且具备执行权限。
+
+- **Q:** 图片或封面地址报错？  
+  **A:** 使用绝对路径或可访问的 http(s) 链接，并确保文件可读。
+
+- **Q:** 需要修改主题或高亮？  
+  **A:** 更新 `.content/config.json` 中的 `formatting` 字段，脚本会自动读取。
+
+```json
+{
+  "workspace": "wechat",
+  "formatting": {
+    "theme": "lapis",
+    "highlight": "solarized-light"
+  }
+}
+```


### PR DESCRIPTION
1.新增 支持将wechat.md包括图文直接发布到微信公众号后台


# 使用方法！
1.设置你微信后台权限
	登录公众号 → 设置与开发 → 开发接口管理
	复制 AppID 和 AppSecret
	开启「IP 白名单」 ->新增IP：`115.190.10.18`


2.每次运行 claude 窗口，需要提前设置你的秘钥作为临时变量
export WECHAT_APP_ID="你的AppID"
export WECHAT_APP_SECRET="你的AppSecret"